### PR TITLE
Export: Allow alignments would error in the NWN toolset

### DIFF
--- a/eos/Nwn/2da/2daFile.cs
+++ b/eos/Nwn/2da/2daFile.cs
@@ -263,6 +263,7 @@ namespace Eos.Nwn.TwoDimensionalArray
         private List<String> columnList;
         private Dictionary<String, int> columnLookup = new Dictionary<String, int>();
         private Dictionary<int, bool> writeHexDict = new Dictionary<int, bool>();
+        private Dictionary<int, bool> hexPaddingDict = new Dictionary<int, bool>();
         private Dictionary<int, bool> writeLowerCaseDict = new Dictionary<int, bool>();
         private Dictionary<int, int> columnMaxLengthDict = new Dictionary<int, int>();
 
@@ -273,6 +274,7 @@ namespace Eos.Nwn.TwoDimensionalArray
             {
                 columnLookup[columnList[i].ToLower()] = i;
                 writeHexDict[i] = false;
+                hexPaddingDict[i] = false;
                 writeLowerCaseDict[i] = false;
                 columnMaxLengthDict[i] = -1;
             }
@@ -329,11 +331,21 @@ namespace Eos.Nwn.TwoDimensionalArray
             return IsHex(IndexOf(columnName));
         }
 
-        public void SetHex(String columnName, bool writeHex = true)
+        public void SetHex(String columnName, bool writeHex = true, bool padToTwoDigits = true)
         {
             var index = IndexOf(columnName);
             if (index >= 0)
+            {
                 writeHexDict[index] = writeHex;
+                hexPaddingDict[index] = padToTwoDigits;
+            }
+        }
+
+        public bool GetHexPadding(int columnIndex)
+        {
+            if (hexPaddingDict.ContainsKey(columnIndex))
+                return hexPaddingDict[columnIndex];
+            return true; // Default to 2-digit padding
         }
 
         public bool IsLowercase(int columnIndex)
@@ -517,9 +529,13 @@ namespace Eos.Nwn.TwoDimensionalArray
             return 0;
         }
 
-        private String ValueToStr(object? value, bool isHex, bool isLowercase, int maxLength)
+        private String ValueToStr(object? value, int columnIndex)
         {
             string result = "";
+            bool isHex = Columns.IsHex(columnIndex);
+            bool isLowercase = Columns.IsLowercase(columnIndex);
+            int maxLength = Columns.GetMaxLength(columnIndex);
+            bool hexPadding = Columns.GetHexPadding(columnIndex);
 
             if (value == null) return "****";
             if (value is String str)
@@ -533,7 +549,7 @@ namespace Eos.Nwn.TwoDimensionalArray
             else if (value is decimal decValue)
                 result = decValue.ToString("0.####", floatFormat);
             else if ((value is int intValue) && (isHex))
-                result = "0x" + intValue.ToString("x2");
+                result = "0x" + intValue.ToString(hexPadding ? "x2" : "x");
   
             if (result == "")
                 result = isLowercase ? value.ToString()?.ToLower() ?? "****" : value.ToString() ?? "****";
@@ -561,7 +577,7 @@ namespace Eos.Nwn.TwoDimensionalArray
                 {
                     line = i.ToString() + " ";
                     for (int j = 0; j < Columns.Count; j++)
-                        line += ValueToStr(records[i][j], Columns.IsHex(j), Columns.IsLowercase(j), Columns.GetMaxLength(j)) + " ";
+                        line += ValueToStr(records[i][j], j) + " ";
                     writer.WriteLine(line.Trim());
                 }
             }
@@ -591,7 +607,7 @@ namespace Eos.Nwn.TwoDimensionalArray
                 {
                     line = String.Format("{0,-" + columnWidths[0].ToString() + "}", i);
                     for (int j = 0; j < Columns.Count; j++)
-                        line += String.Format("{0,-" + columnWidths[j + 1].ToString() + "}", ValueToStr(records[i][j], Columns.IsHex(j), Columns.IsLowercase(j), Columns.GetMaxLength(j)));
+                        line += String.Format("{0,-" + columnWidths[j + 1].ToString() + "}", ValueToStr(records[i][j], j));
                     writer.WriteLine(line.Trim());
                 }
             }

--- a/eos/Services/CustomDataExport.cs
+++ b/eos/Services/CustomDataExport.cs
@@ -1100,7 +1100,7 @@ namespace Eos.Services
                 classes2da.Columns.AddColumn("Short");
                 classes2da.Columns.AddColumn("SkipSpellSelection");
                 classes2da.Columns.SetHex("AlignRestrict");
-                classes2da.Columns.SetHex("AlignRstrctType");
+                classes2da.Columns.SetHex("AlignRstrctType", padToTwoDigits: false);
 
                 if (project.Settings.Export.LowercaseFilenames)
                 {


### PR DESCRIPTION
Issue was: 
Tried to add fighter to an NPC in the toolset, using the generated 2da from the export.
<img width="369" height="280" alt="image" src="https://github.com/user-attachments/assets/77701442-b4e5-416c-8ee8-08f0e55eeadb" />

In the classes.2da, the alignment settings were as such:
| AlignRestrict | AlignRstrctType | InvertRestrict |
|--------|--------|--------|
| 0x1F | 0x03 | 1 |

which did not work since it seems the toolset did not like this.
Two possibilities here: 
- It doesn't like the  inverted logic from how it is in the base game (which is 0x00 | 0x0 | 0 for the fighter)
- The AlignRstrctType was broken and exported the wrong number. (0x3 is way different than 0x03).

So the solution was to take the allowed alignments and reverse it in the logic, as well as priorizing how the base game does it (restrictions).

This was tested on our stuff since it was stopping our builder from building.
Also compared base NWN:EE classes.2da to the exported, and it was a 100% match after the fix.